### PR TITLE
Known issue template

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -108,9 +108,10 @@ Create a new project version under the specified project
 
 #### Parameters
 *project_name*</br>
-*param project_id*</br>
 *param project_template*</br>
 *param version_name*</br>
+*param project_id*</br>
+*param issue_template_id*</br>
 
 - - -
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -103,15 +103,15 @@ Convenience function to set the 'committed' project version attribute to True
 
 - - -
 
-### Create Project Version:
-Create a new project version under the specified project
+### Create Application Version:
+Create a new application (formerly project) version under the specified project
 
 #### Parameters
-*project_name*</br>
-*param project_template*</br>
+*application_name*</br>
+*param application_template*</br>
 *param version_name*</br>
-*param project_id*</br>
-*param issue_template_id*</br>
+*param application_id (optional)*</br>
+*param issue_template_id (optional)*</br>
 
 - - -
 

--- a/fortifyapi/fortify.py
+++ b/fortifyapi/fortify.py
@@ -220,22 +220,24 @@ class FortifyApi(object):
         return self._request('GET', url)
 
     def create_application_version(self, application_name, application_template, version_name, description,
-                                   application_id=None):
+                                   application_id=None, issue_template_id=None):
         """
         :param application_name: Project name
         :param application_id: Project ID
         :param application_template: Application template name
         :param version_name: Version name
         :param description: Application Version description
+        :param issue_template_id: Optional for when you already know the id you want to use
         :return: A response object containing the created project version
         """
         # If no application ID is given, sets JSON value to null.
         if application_id is None:
             application_id = 'null'
 
-        # Gets Template ID
-        issue_template = self.get_issue_template_id(project_template_name=application_template)
-        issue_template_id = issue_template.data['data'][0]['id']
+        if issue_template_id is None:
+            # Gets Template ID
+            issue_template = self.get_issue_template_id(project_template_name=application_template)
+            issue_template_id = issue_template.data['data'][0]['id']
 
         data = dict(name=version_name,
                     description=description,

--- a/setup.py
+++ b/setup.py
@@ -51,5 +51,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: Implementation ::CPython'
-    ],
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -48,9 +48,12 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development',
         'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Software Development :: Libraries :: Application Frameworks',
+        'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
-    ]
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: Implementation ::CPython'
+    ],
 )


### PR DESCRIPTION
The need for an optional issue_template_id comes from my own enterprise experience. In my case the security group that manages the ci/cd token permissions is reluctant/slow to approve the additional access required for the issueTemplates endpoint. In our case the issue template id is always known ahead of time, so not having to query the endpoint is a workable solution. 