### PR TITLE
Implementation of the method get_source_file

### DIFF
--- a/fortifyapi/__init__.py
+++ b/fortifyapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.0.1'
+__version__ = '3.0.2'
 
 from fortifyapi.client import *
 from fortifyapi.api import *

--- a/fortifyapi/fortify.py
+++ b/fortifyapi/fortify.py
@@ -651,6 +651,17 @@ class FortifyApi(object):
         url = '/api/v1/issueDetails/' + str(issue_id)
         return self._request('GET', url)
 
+    def get_project_version_source_file(self, version_id, path):
+        """
+        Returns an object with information on a source file from a specific project version.
+        It includes the file content.
+        :param version_id: application version id
+        :param path: the relative path of the file from the project root folder
+        :return: details on a source file
+        """
+        url = f'/api/v1/projectVersions/{version_id}/sourceFiles?q=path:"{path}"'
+        return self._request("GET", url)
+
     def get_cloud_pool_list(self):
         """
         Get listing of all cloud pools


### PR DESCRIPTION
It uses the endpoint:
  /api/v1/projectVersions/{version_id}/sourceFiles?q=path:"{path}"

Retrieves a file object, including its content.

Useful for getting the source file content and use it to show the
exact error location.