### PR TITLE
Scratch/cloudscan worker and pool endpoints

### DIFF
--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -347,15 +347,12 @@ class CloudPool(SSCObject):
         with self._api as api:
             return api.delete(f"/api/v1/cloudpools/{self['uuid']}")
 
-    def assign(self, worker_uuids):
-        self.assert_is_instance()
-        if not isinstance(worker_uuids, list):
-            worker_uuids = [worker_uuids]
+    def assign(self, pool_uuid, worker_uuid):
         with self._api as api:
-            r = api.post(f"/api/v1/cloudpools/{self['uuid']}/workers/action/assign", {
-                "workerUuids": worker_uuids
+            r = api.post(f"/api/v1/cloudpools/{pool_uuid}/workers/action/assign", {
+                                                 "worker": worker_uuid
             })
-            #TODO: figure out what this returns
+            return CloudPool(self._api, r['data'])
 
     def jobs(self):
         self.assert_is_instance()

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -386,9 +386,12 @@ class CloudJob(SSCObject):
         with self._api as api:
             return CloudJob(self._api, api.get(f"/api/v1/cloudjobs/{job_token}")['data'], self.parent)
 
-    def cancel(self):
+    def cancel(self, job_token):
         with self._api as api:
-            return api.post(f"/api/v1/cloudjobs/action/cancel", jobTokens=[self['jobToken']])
+            r = api.post(f"/api/v1/cloudjobs/P{job_token}/acion", {
+                "type": "cancel"
+            })
+            return CloudJob(self._api, r['data'])
 
 
 class Scan(SSCObject):

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -391,21 +391,17 @@ class CloudJob(SSCObject):
         with self._api as api:
             return CloudJob(self._api, api.get(f"/api/v1/cloudjobs/{job_token}")['data'], self.parent)
 
-    def cancel(self, job_token):
+    def cancel(self, job_token: str):
+        """
+        Manage ScanCentral SAST jobs with state change to CANCEL.  Typical usage
+        would be of a large backlog of PENDING jobs, because no sensor was available or is in a bad state.
+        :param job_token: Scan Central Job Token assigned to the job
+        TODO: fix with return api.post(f"/api/v1/cloudjobs/{job_token}/acion", type="cancel")['data']['status'].  See
+        POST /ssc/api/v1/cloudjobs/1076964f-ec72-48e1-a897-6da9683a75df/action HTTP/1.1
+        {"type":"cancel"}
+        """
         with self._api as api:
-            r = api.post(f"/api/v1/cloudjobs/P{job_token}/acion", {
-                "type": "cancel"
-            })
-            return CloudJob(self._api, r['data']['status'])
-
-    # def cancel(self, job_token: str):
-    #     """
-    #     Manage ScanCentral SAST jobs with state change to CANCEL.  Typical usage
-    #     would be of a large backlog of PENDING jobs, because no sensor was available or is in a bad state.
-    #     :param job_token: Scan Central Job Token assigned to the job
-    #     """
-    #     with self._api as api:
-    #         return api.post(f"/api/v1/cloudjobs/{job_token}/acion", type="cancel")['data']['status']
+            return api.post (f"/api/v1/cloudjobs/action/cancel", jobTokens=[self['jobToken']])
 
 
 class Scan(SSCObject):

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -386,13 +386,14 @@ class CloudJob(SSCObject):
         with self._api as api:
             return CloudJob(self._api, api.get(f"/api/v1/cloudjobs/{job_token}")['data'], self.parent)
 
-    def cancel(self, job_token):
+    def cancel(self, job_token: str):
+        """
+        Manage ScanCentral SAST jobs with state change to CANCEL.  Typical usage
+        would be of a large backlog of PENDING jobs, because no sensor was available or is in a bad state.
+        :param job_token: Scan Central Job Token assigned to the job
+        """
         with self._api as api:
-            r = api.post(f"/api/v1/cloudjobs/P{job_token}/acion", {
-                "type": "cancel"
-            })
-            return CloudJob(self._api, r['data'])
-
+            return api.post(f"/api/v1/cloudjobs/{job_token}/acion", type=cancel)['data']['status']
 
 class Scan(SSCObject):
 

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -313,7 +313,6 @@ class Project(SSCObject):
                 raise ParentNotFoundException(f"Somehow `{project_name}` and version `{version_name}` exists yet we cannot query for it")
             return versions[0]
 
-
     def delete(self):
         # delete every version and project will delete
         self.assert_is_instance()
@@ -350,8 +349,8 @@ class CloudPool(SSCObject):
 
     def assign(self, pool_uuid, worker_uuid):
         """
-        This endpoint is one of two that can be implemented, the other is a Post bulk request implementing the below uri,
-        "https://fortify.example.com/ssc/api/v1/cloudpools/{pool_uuid}/versions/action".
+        This endpoint is one of two that can be implemented, the other is a Post bulk request
+        implementing "https://fortify.example.com/ssc/api/v1/cloudpools/{pool_uuid}/versions/action".
         Either one will work
         :param pool_uuid:
         :param worker_uuid:
@@ -360,7 +359,7 @@ class CloudPool(SSCObject):
         with self._api as api:
             r = api.post(f"/api/v1/cloudpools/{pool_uuid}/workers/action", {
                 "type": "assign",
-                "ids": [worker_uuid]
+                "ids": [worker_uuid] if type(worker_uuid) is str else list(worker_uuid)
             })
             return CloudPool(self._api, r['data'])
 
@@ -411,7 +410,7 @@ class CloudJob(SSCObject):
         {"type":"cancel"}
         """
         with self._api as api:
-            return api.post (f"/api/v1/cloudjobs/action/cancel", jobTokens=[self['jobToken']])
+            return api.post(f"/api/v1/cloudjobs/action/cancel", jobTokens=[self['jobToken']])
 
 
 class Scan(SSCObject):

--- a/fortifyapi/fortify.py
+++ b/fortifyapi/fortify.py
@@ -379,6 +379,13 @@ class FortifyApi(object):
         url = '/api/v1/cloudjobs/' + scan_id
         return self._request('GET', url)
 
+    def set_cloudscan_cancel_job(self, scan_id):
+        url = '/api/v1/cloudjobs/' + scan_id + '/action'
+        data = (
+            {"type": "cancel"}
+        )
+        return self._request('POST', url, json=data)
+
     def get_file_token(self, purpose):
         """
         :param purpose: specify if the token is for file 'UPLOAD' or 'DOWNLOAD'

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -64,15 +64,26 @@ class TestPools(TestCase):
         jobs = list(pools[0].jobs())
         self.assertIsNotNone(jobs)
 
-    def test_assign_worker(self):
-        pool_name = 'unit_test_pool_assign_worker_zz'
+    def test_unassign_worker(self):
+        unassigned_pool = '00000000-0000-0000-0000-000000000001'
         client = FortifySSCClient(self.c.url, self.c.token)
         self.c.setup_proxy(client)
-        new_pool = client.pools.create(pool_name)
+        worker = [worker['uuid'] for worker in client.workers.list() if worker['totalPhysicalMemory'] < 30000000000]
+        unassign = client.pools.assign(worker_uuid=worker[0], pool_uuid=unassigned_pool)
+        print(f"{unassign['status']} worker {worker[0]} has been unassigned to the unassigned pool {unassigned_pool}")
+        return worker[0]
+
+    def test_assign_worker(self):
+        pool_name = 'unit_test_pool_zz'
+        client = FortifySSCClient(self.c.url, self.c.token)
+        self.c.setup_proxy(client)
+        existing_pool = [pool['name'] for pool in client.pools.list()]
+        pool = [x for x in pool_name if x not in existing_pool]
+        new_pool = client.pools.create(pool)
         pprint(new_pool)
 
-        # Assign a worker that is unassigned to a pool
-        unassigned_worker = [worker['uuid'] for worker in client.workers.list() if worker['cloudPool'] is None]
+        unassigned_worker = [worker['uuid'] for worker in client.workers.list() if worker['cloudPool'] is
+                             "Unassigned Sensors Pool" == worker['cloudPool']['name']]
         unit_test_pool = list(client.pools.list(q=Query().query('name', pool_name)))
         pool_uuid = next(unit_test_pool)['uuid']
         self.assertIsNotNone(pool_uuid)

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -45,6 +45,7 @@ class TestPools(TestCase):
         pprint(new_pool)
         self.assertIsNotNone(new_pool)
 
+        new_worker = client.pools.
         pools = list(client.pools.list(q=Query().query('name', pool_name)))
         self.assertIsNotNone(pools)
         self.assertEqual(1, len(pools))
@@ -64,5 +65,13 @@ class TestPools(TestCase):
         jobs = list(pools[0].jobs())
         self.assertIsNotNone(jobs)
 
+    def test_add_pools(self):
+        client = FortifySSCClient(self.c.url, self.c.token)
+        self.c.setup_proxy(client)
+        self.assertIsNotNone(pools)
+        self.assertEqual(1, len(pools))
+        pools = list(client.pools.list(q=Query().query('name', 'Default Pool')))
+
+    def test_add_pools(self):
 
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -45,7 +45,6 @@ class TestPools(TestCase):
         pprint(new_pool)
         self.assertIsNotNone(new_pool)
 
-        new_worker = client.pools.
         pools = list(client.pools.list(q=Query().query('name', pool_name)))
         self.assertIsNotNone(pools)
         self.assertEqual(1, len(pools))
@@ -65,13 +64,21 @@ class TestPools(TestCase):
         jobs = list(pools[0].jobs())
         self.assertIsNotNone(jobs)
 
-    def test_add_pools(self):
+    def test_assign_worker(self):
+        pool_name = 'unit_test_pool_assign_worker_zz'
         client = FortifySSCClient(self.c.url, self.c.token)
         self.c.setup_proxy(client)
-        self.assertIsNotNone(pools)
-        self.assertEqual(1, len(pools))
-        pools = list(client.pools.list(q=Query().query('name', 'Default Pool')))
+        new_pool = client.pools.create(pool_name)
+        pprint(new_pool)
 
-    def test_add_pools(self):
+        # Assign a worker that is unassigned to a pool
+        unassigned_worker = [worker['uuid'] for worker in client.workers.list() if worker['cloudPool'] is None]
+        unit_test_pool = list(client.pools.list(q=Query().query('name', pool_name)))
+        pool_uuid = next(unit_test_pool)['uuid']
+        self.assertIsNotNone(pool_uuid)
+        client.pools.assign(worker_uuid=unassigned_worker, pool_uuid=pool_uuid)
+        worker = [worker['uuid'] for worker in client.workers.list() if worker['cloudPool'] == unit_test_pool]
+        self.assertNotEqual(len(worker), 0)
+
 
 


### PR DESCRIPTION
add worker assignment, test, and documentation for cancel job to legacy.