### PR TITLE
query the inactive

### DIFF
--- a/fortifyapi/api.py
+++ b/fortifyapi/api.py
@@ -109,6 +109,18 @@ class FortifySSCAPI:
         return self.post('/api/v1/bulk', requests=reqs)
 
     def page_data(self, endpoint, **kwargs):
+        """
+        The available query parameters:
+        
+        * q - field name + value pair that filters results, see Query
+        * fields - comma-delimited list of fields to include in response
+        * orderby - field name by which to order results
+        * includeInactive - default is false
+
+        :param endpoint: 
+        :param kwargs: 
+        :return: 
+        """
         if 'start' not in kwargs:
             kwargs['start'] = 0
         if 'limit' not in kwargs:

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -128,10 +128,6 @@ class Version(SSCObject):
         with self._api as api:
             return Version(self._api, api.get(f"/api/v1/projectVersions/{id}")['data'], self.parent)
 
-    def project_exist(self):
-        with self._api as api:
-            return
-
     def delete(self):
         """ Delete the current version """
         self.assert_is_instance()
@@ -303,14 +299,16 @@ class Project(SSCObject):
                                active=active, committed=committed, issue_template_id=issue_template_id,
                                template=template)
         else:
+            # almost for sure an inactive project version if test passed
             q = Query().query("name", project_name)
             projects = list(self.list(q=q))
             if len(projects) == 0:
                 raise ParentNotFoundException(f"Somehow `{project_name}` exists yet we cannot query for it")
+            # we know the project exists ...
             project = projects[0]
-            versions = list(project.versions.list(q=Query().query("name", version_name)))
+            versions = list(project.versions.list(q=Query().query("name", version_name), includeInactive='true'))
             if len(versions) == 0:
-                raise ParentNotFoundException(f"Somehow `{project_name}` and version `{version_name}` exists yet we cannot query for it")
+                raise ParentNotFoundException(f"Somehow `{project_name}` and Version `{version_name}` exists but cannot be queried - did we actually include inactive?")
             return versions[0]
 
     def delete(self):

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -111,6 +111,11 @@ class Version(SSCObject):
                            template=CloneVersionTemplate(self['id']))
 
     def list(self, **kwargs):
+        """
+
+        :param kwargs:
+        :return:
+        """
         if not self.parent:
             raise ParentNotFoundException("No project parent found to query versions from")
         with self._api as api:

--- a/fortifyapi/query.py
+++ b/fortifyapi/query.py
@@ -18,16 +18,46 @@ class AndCondition(Condition):
 class Query:
 
     def __init__(self, query_obj=None):
+        """
+         When retrieving a list of resources it is possible to filter and sort that list using query parameters.
+         For example, `/api/v1/projects?q=createdBy:admin&orderby=id` will return the list of projects that were
+         created by "admin" sorted by the "id" (by default they're sorted by name).
+
+        The query itself is field name + value pair that filters results, and the Query object helps generate the values.
+        The available query parameters are:
+        For example:
+        ```
+        q = Query().query("name", "Unit Test Python")
+        for project in client.projects.list(q=q, orderby='id'):
+        ```
+
+        :param query_obj: A dict to seed this query
+        :type query_obj: dict
+        """
         self.__queries = []
         if query_obj:
             for k, v in query_obj.items():
                 self.query(k, v)
 
     def query(self, name, value):
+        """
+        Add to the query
+
+        :param name: Name
+        :param value: Value
+        :return: self for chaining
+        :rtype: :py:class:`query.Query`
+        """
         self.__queries.append(AndCondition(name, value))
         return self
 
     def generate(self):
+        """
+        Generate the query string to use with the `q` parameter
+
+        :return: the query string
+        :rtype: str
+        """
         ret = ''
         if len(self.__queries) > 0:
             ret += str(self.__queries[0])


### PR DESCRIPTION
api shouldn't care if things are active or not when upserting