### PR TITLE
Scratch/project version query

### DIFF
--- a/fortifyapi/__init__.py
+++ b/fortifyapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.6'
+__version__ = '3.1.7'
 
 from fortifyapi.client import *
 from fortifyapi.query import Query

--- a/fortifyapi/fortify.py
+++ b/fortifyapi/fortify.py
@@ -468,11 +468,11 @@ class FortifyApi(object):
         url = "/api/v1/projectVersions?limit=0&q=project.name:\"" + project_name + "\""
         return self._request('GET', url)
 
-    def get_version(self, version_name):
+    def get_version(self, version_name, project_name):
         """
         :return: A response object with data containing just a project's version
         """
-        url = "/api/v1/projectVersions?q=name:\"" + version_name + "\""
+        url = "/api/v1/projectVersions?q=name:\"" + version_name + "\"&q=project.name:\"" + project_name + "\""
         return self._request('GET', url)
 
     def set_project_versions_test(self, project_name, project_version_name):

--- a/fortifyapi/fortify.py
+++ b/fortifyapi/fortify.py
@@ -459,20 +459,22 @@ class FortifyApi(object):
         url = "/api/v1/projectVersions/" + version_id
         return self._request('GET', url)
 
-    def get_project_versions(self, project_name):
+    def get_project_versions(self, project_name=None, version_name=None):
         """
         Implemented on SSC as project-version-controller to manage application versions.
         A variety of associated resources are accessible via links.
+        :param project_name: SSC Application or Project name
+        :param version_name: SSC Application or Project version name
         :return: A response object with data containing project versions
         """
-        url = "/api/v1/projectVersions?limit=0&q=project.name:\"" + project_name + "\""
+        url = f"/api/v1/projectVersions?limit=0&q=project.name:{project_name}&q=name:{version_name}"
         return self._request('GET', url)
 
-    def get_version(self, version_name, project_name):
+    def get_version(self, version_name):
         """
         :return: A response object with data containing just a project's version
         """
-        url = "/api/v1/projectVersions?q=name:\"" + version_name + "\"&q=project.name:\"" + project_name + "\""
+        url = "/api/v1/projectVersions?q=name:\"" + version_name + "\""
         return self._request('GET', url)
 
     def set_project_versions_test(self, project_name, project_version_name):

--- a/fortifyapi/fortify.py
+++ b/fortifyapi/fortify.py
@@ -459,10 +459,11 @@ class FortifyApi(object):
         url = "/api/v1/projectVersions/" + version_id
         return self._request('GET', url)
 
-    def get_project_versions(self, project_name=None, version_name=None):
+    def get_projects_version(self, project_name=None, version_name=None):
         """
         Implemented on SSC as project-version-controller to manage application versions.
-        A variety of associated resources are accessible via links.
+        Changed this query to have greater precision over get_version, to select a given
+        version within the project or application.
         :param project_name: SSC Application or Project name
         :param version_name: SSC Application or Project version name
         :return: A response object with data containing project versions


### PR DESCRIPTION
refactored get_project_versions to get_projects_version to query both the project and versions.