### PR TITLE
feat: fix project query issue

### DIFF
--- a/fortifyapi/__init__.py
+++ b/fortifyapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.19'
+__version__ = '3.1.20'
 
 from fortifyapi.client import *
 from fortifyapi.query import Query

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -314,7 +314,11 @@ class Project(SSCObject):
             q = Query().query("name", project_name)
             projects = list(self.list(q=q))
             if len(projects) == 0:
-                raise ParentNotFoundException(f"Somehow `{project_name}` exists yet we cannot query for it")
+                # sometimes the project exists but we can't query for it, this helps often enough
+                q = Query().query("name", f"*{project_name}*")
+                projects = list(self.list(q=q))
+                if len(projects) == 0:
+                    raise ParentNotFoundException(f"Somehow `{project_name}` exists yet we cannot query for it")
             project = projects[0]
             return self.create(project_name, version_name, project_id=project['id'], description=description,
                                active=active, committed=committed, issue_template_id=issue_template_id,


### PR DESCRIPTION
The only way via API to find a project is is by search, and sometimes it does not work even if the `project.test(name)` function finds it -- This fix will help alleviate that by reproducing what the UI does to find the same project name.