### PR TITLE
fix: unicode project version fix

### DIFF
--- a/fortifyapi/__init__.py
+++ b/fortifyapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.20'
+__version__ = '3.1.21'
 
 from fortifyapi.client import *
 from fortifyapi.query import Query

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -304,12 +304,6 @@ class Project(SSCObject):
             p = Project(self._api, {}, None).get(p['id'])
             return p.versions.get(v['id'])
 
-    def search(self, project_name, version_name=None):
-        q = Query().query("project.name", pname)
-        if pver:
-            q = q.query("name", pver)
-        versions = next(self.versions.list(q=q), None)
-
     def upsert(self, project_name, version_name, description="Created on " + str(date.today())
                + " from " + gethostname(), active=True,
                committed=False, issue_template_id='Prioritized-HighRisk-Project-Template',


### PR DESCRIPTION
When dealing with unicode project names, the project endpoint does not work -- 

`/ssc/api/v1/projects?q=name%3A%22*bla%20xyz%20%E2%80%91%20zzz%E2%80%8B*%22` returns no hits yet `/ssc/api/v1/projectVersions?q=project.name%3A%22*bla%20xyz%20%E2%80%91%20zzz%E2%80%8B*%22` returns a result -- though mindfully with the db in ascii (not unicode) the resultant return project name still replaces the unicode with the literal `?`