### PR TITLE
fix: rule upload

### DIFF
--- a/fortifyapi/__init__.py
+++ b/fortifyapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.1.23'
+__version__ = '3.1.24'
 
 from fortifyapi.client import *
 from fortifyapi.query import Query

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -759,10 +759,6 @@ class Token(SSCObject):
 
 class Rulepack(SSCObject):
 
-    def get(self):
-        with self._api as api:
-            return Rulepack(self._api, api.get(f"/api/v1/coreRulepacks")['data'], self.parent)
-
     def list(self, **kwargs):
         with self._api as api:
             for e in api.page_data(f"/api/v1/coreRulepacks", **kwargs):

--- a/fortifyapi/client.py
+++ b/fortifyapi/client.py
@@ -770,15 +770,19 @@ class Rulepack(SSCObject):
 
     def upload(self, file_path):
         """
+        Known return 'code' values:
+        * -10000: good -- messages vary
+        * -10003: bad -- messages vary
+
         :param file_path str: The path to the rulepack file to upload
-        :return: a Rulepack object
+        :return: list(`RulepacksBatchProcessStatus`) - Normally `[{'code': -10000, 'message': 'some message', 'rulepackResourceId': 1234}]`
         """
         assert file_path, "file_path is required"
         assert exists(file_path), "file_path does not exist"
 
         with self._api as api:
             with open(file_path, 'rb') as f:
-                return Rulepack(self._api, api._request('post', "/api/v1/coreRulepacks", files={'file': f})['data'], self.parent)
+                return api._request('post', "/api/v1/coreRulepacks", files={'file': f})['data']
 
     def delete(self):
         self.assert_is_instance()


### PR DESCRIPTION
Return is like `{'data': [{'code': -10000, 'message': 'The rulepack "..." version 1.0 has been replaced.', 'rulepackResourceId': 1234}], 'responseCode': 200}` -- so it's not a `Rulepack` obj like expected and it's a list. Just return the list.

Also remove the duplicate method that almost certainly did not work, as it set a list into a dict.