### PR TITLE
Fix invalid previousProjectVersionId value in copy_from_partial template

### DIFF
--- a/fortifyapi/template.py
+++ b/fortifyapi/template.py
@@ -75,7 +75,7 @@ class DefaultVersionTemplate:
                 "type": "COPY_FROM_PARTIAL",
                 "values": {
                     "projectVersionId": self.project_version_id,
-                    "previousProjectVersionId": -1,
+                    "previousProjectVersionId": None,
                     "copyAnalysisProcessingRules": True,
                     "copyBugTrackerConfiguration": True,
                     "copyCurrentStateFpr": False,
@@ -95,7 +95,7 @@ class DefaultVersionTemplate:
                 "type": "COPY_CURRENT_STATE",
                 "values": {
                     "projectVersionId": self.project_version_id,
-                    "previousProjectVersionId": -1,
+                    "previousProjectVersionId": None,
                     "copyCurrentStateFpr": False
                 }
             }


### PR DESCRIPTION
## Bug Fix: Invalid previousProjectVersionId Value

### Problem
The `copy_from_partial()` and `copy_project_version_state()` methods in `fortifyapi/template.py` hardcoded `previousProjectVersionId` to `-1`, which is not a valid project version ID.

### Impact
This causes the Fortify SSC API to reject the request with a validation error, as the API expects either:
- A valid project version ID (positive integer)
- `null`/`None` for new projects

### Solution
Changed `previousProjectVersionId` from `-1` to `None` in both methods. When serialized to JSON, `None` becomes `null`, which is the correct value for new projects without a previous version.

### Files Changed
- `fortifyapi/template.py`: Fixed `previousProjectVersionId` in `copy_from_partial()` and `copy_project_version_state()` methods

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.